### PR TITLE
enable switching off parallel execution

### DIFF
--- a/run_post_install_tests.bats
+++ b/run_post_install_tests.bats
@@ -25,6 +25,7 @@
     run rm -f $tool_perf_table && get_tool_performance_table.R\
                                     --input-dir $eval_input_dir\
                                     --barcode-col-ref $barcode_col_ref\
+                                    --parallel $parallel\
                                     --num-cores $num_cores\
                                     --barcode-col-pred $barcode_col_pred\
                                     --label-column-ref $label_column_ref\
@@ -49,6 +50,7 @@
     run rm -f $empirical_dist && get_empirical_dist.R\
                                     --input-ref-file $ref_labels_file\
                                     --label-column-ref $label_column_ref\
+                                    --parallel $parallel\
                                     --num-iterations $num_iter\
                                     --lab-cl-mapping $label_cl_dict\
                                     --num-cores $num_cores\
@@ -107,6 +109,7 @@
                      --input-dir $combined_tools_results\
                      --tool-table $tool_perf_table\
                      --cl-dictionary $label_cl_dict\
+                     --parallel $parallel\
                      --ontology-graph $ontology_graph\
                      --num-cores $num_cores\
                      --summary-table-output-path $summary_table_path\

--- a/run_post_install_tests.sh
+++ b/run_post_install_tests.sh
@@ -63,6 +63,7 @@ export raw_labels_table_path=$output_dir/'raw_labels_table.tsv'
 export summary_table_path=$output_dir/'summary_output_table.tsv'
 
 export num_iter=5
+export parallel='TRUE'
 export num_cores=4
 export top_labels_num=2
 export use_existing_outputs


### PR DESCRIPTION
- Galaxy wrappers keep complaining about parallel execution, so had to add an option to disable it (v. annoying!) 
- Will address the galaxy problem later

- Also, spotted that in one of the scripts a log of semantic similarity is returned, which was incorrect. (Log-values for sem. similarity are used when calculating combined tool score so as to reduce its relative weight. Otherwise, values are returned as they are)