### PR TITLE
fix bugs in CL computations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ A common output format across tools is assumed - a tab-separated table with 3 co
 |ERR2632412 | memory B cell | 0.8|
 |ERR2632413 | memory B cell | 0.8|
 
+* Metadata 
+In order to keep track of information about tool and training dataset which produced given table, add metadata fields to the top of the file in the following format:
+```
+# tool <tool> 
+# dataset <dataset> 
+``` 
 
 ### Production scenario (novel data)
 In production scenario, we are interested in getting as accurate predictions for novel data as possible. To do so, we run a host of pre-trained classifiers against an incoming data set. Then, we aggregate predictions on a single tool basis and select top ones based on corresponding scores (`combine_tool_outputs.R`).

--- a/build_cell_ontology_dict.R
+++ b/build_cell_ontology_dict.R
@@ -80,10 +80,10 @@ if(condensed){
         # select rows which have cell type 
         df = df[df[, 5] == "cell type", ]
         cell_labs = tolower(df[, 6])
-        cl_terms = tolower(df[, 7])
+        cl_terms = df[, 7]
     } else {
         cell_labs = tolower(df[, opt$cell_label_col_name])
-        cl_terms = tolower(df[, opt$cell_ontology_col_name])
+        cl_terms = df[, opt$cell_ontology_col_name]
     }
     
     for(idx in seq_along(cell_labs)){

--- a/build_cell_ontology_dict.R
+++ b/build_cell_ontology_dict.R
@@ -51,7 +51,14 @@ option_list = list(
         default = NA,
         type = 'character',
         help = 'Output path for serialised object containing the dictionary'
-    ) 
+    ),
+    make_option(
+        c("-t", "--output-text-path"),
+        action = "store",
+        default = NA,
+        type = 'character',
+        help = 'Output path for txt version of label - term mapping'
+    )
 )
 
 # parse arguments 
@@ -107,5 +114,4 @@ out_path = opt$output_dict_path
 saveRDS(cell_type_id_mapping, out_path)
 # save a human-readable version of the dictionary 
 label_cl_table = data.frame(cell_labels=keys(cell_type_id_mapping), CL_terms=values(cell_type_id_mapping))
-out_path = sub("rds", "tsv", out_path)
-write.table(label_cl_table, file=out_path, sep="\t", row.names=FALSE)
+write.table(label_cl_table, file=opt$output_text_path, sep="\t", row.names=FALSE)

--- a/cell_types_utils.R
+++ b/cell_types_utils.R
@@ -217,7 +217,6 @@ get_top_labels = function(label_list, tool_scores=NULL){
     # determine frequency of each unique label 
     .get_freq = function(lab, n_labs){
         freq = as.numeric(table(label_list)[lab] / n_labs)
-        #print(paste("freq", freq))
         return(round(freq, 3))
     }
     freqs = sapply(unq_labs, function(lab) .get_freq(lab, n_labs=length(label_list)))

--- a/cell_types_utils.R
+++ b/cell_types_utils.R
@@ -108,10 +108,9 @@ get_CL_similarity = function(label_1, label_2, lab_cl_mapping, ontology, sim_met
     }
     term_1 = lab_cl_mapping[[as.character(label_1)]]
     term_2 = lab_cl_mapping[[as.character(label_2)]]
-
     # semantic similarity 
     tryCatch({
-        psim = pairsim(siml_object, term_1, term_2)
+        psim = round(pairsim(siml_object, term_1, term_2), 3)
         return(psim)
         },
     error = function(cond){

--- a/cell_types_utils.R
+++ b/cell_types_utils.R
@@ -216,18 +216,20 @@ get_top_labels = function(label_list, tool_scores=NULL){
     unq_labs = unique(label_list)
     # determine frequency of each unique label 
     .get_freq = function(lab, n_labs){
-        freq = as.numeric(table(labels)[lab] / n_labs)
+        freq = as.numeric(table(label_list)[lab] / n_labs)
+        #print(paste("freq", freq))
         return(round(freq, 3))
     }
     freqs = sapply(unq_labs, function(lab) .get_freq(lab, n_labs=length(label_list)))
+
     # if tool scores provided, find weighted scores
     if(!is.null(tool_scores)){
         # extract tool name for each label and find corresponding score
         # NB: label vector must contrain corresponding tool in its name, e.g. tool-X_1
-        source_tools = sapply(names(label_list), function(lab) unlist(strsplit(lab, "_"))[1])
+        source_tools = sapply(names(label_list), function(name) unlist(strsplit(name, "_"))[1])
         label_scores = sapply(source_tools, function(tool) tool_scores[tool])
         # find sum of scores corresponding to each label 
-        score_sums = sapply(unq_labs, function(lab) sum(label_scores[which(label_list==lab)]))
+        score_sums = sapply(unq_labs, function(lab) sum(label_scores[which(label_list==lab)], na.rm=TRUE))
         # account for label frequencies and sort
         sorted = sort(score_sums * freqs, decreasing=TRUE, index.return=TRUE, na.last=TRUE)
         score_names = paste("weighted-score", c(1:3), sep="_")
@@ -298,4 +300,24 @@ extract_datasets = function(label_vec, lab_ds_map){
         }
     }
     return(s)
+}
+
+# extract metadata from file into a list 
+extract_metadata = function(file){
+    con = file(file, "r")
+    vals = list()
+    idx = 1
+    while(TRUE){
+        line = readLines(con, 1)
+        if(!startsWith(line, "#")){
+            return(vals)
+        }
+        data = unlist(strsplit(line, " "))
+        # 1st item is '#', 2nd is field name 
+        n = data[2]
+        # extract values 
+        vals[[idx]] = data[-c(1,2)]
+        names(vals)[idx] = tolower(n)
+        idx = idx + 1 
+    }
 }

--- a/combine_tool_outputs.R
+++ b/combine_tool_outputs.R
@@ -43,7 +43,7 @@ option_list = list(
         action = "store",
         default = NA,
         type = 'character',
-        help = 'Path to the output table in text format. The following naming is expected: tool-X_combined.tsv'
+        help = 'Path to the output table in text format'
     )
 )
 
@@ -61,16 +61,20 @@ file_names = list.files(opt$input_dir, full.names=TRUE)
 predicted_labs_tables = lapply(file_names, function(file) read.csv(file, sep="\t",
                                                                    stringsAsFactors=FALSE,
                                                                    comment.char = "#"))
-# extract datasets of origin
-tools = sapply(file_names, function(f) extract_metadata(f)[['tool']])
+
+# extract metadata from tables 
+metadata = lapply(file_names, function(f) extract_metadata(f))
+
+# extract tools of origin
+tools = sapply(metadata, function(l) l[['tool']])
 # check that all tables are produced by the same tool
 if(! length(unique(tools)) == 1){
     stop("Inconsistent tools provided")
 }
-tool = tools[1]
+source_tool = tools[1]
 # add metadata to output file 
-writeLines(paste("# tool", tool, sep=" "), opt$output_table)
-datasets = sapply(file_names, function(f) extract_metadata(f)[['dataset']])
+writeLines(paste("# tool", source_tool, sep=" "), opt$output_table)
+datasets = sapply(metadata, function(l) l[['dataset']])
 
 # check cell ids are identical across tables
 cell_ids = get_unq_cell_ids(predicted_labs_tables)

--- a/get_consensus_output.R
+++ b/get_consensus_output.R
@@ -162,10 +162,9 @@ top_labs = data.frame(t(top_labs))
     label_vec = as.character(labels[iter, ])
     sem_sim = matrix(nrow=length(label_vec), ncol=length(label_vec))
     for(i in 1:length(label_vec)){
-        print(paste("i", i))
-        label_i = label_vec[i]
+        label_i = tolower(label_vec[i])
         for(j in i:length(label_vec)){
-            label_j = label_vec[j]
+            label_j = tolower(label_vec[j])
             sem_sim[i,j] = get_CL_similarity(label_i, label_j, 
                                         lab_cl_mapping=lab_cl_mapping,
                                         ontology=ontology,

--- a/get_empirical_dist.R
+++ b/get_empirical_dist.R
@@ -97,7 +97,7 @@ if(! is.na(opt$exclusions)){
     trivial_terms = tolower(e$trivial_terms)
 }
 
-reference_labs_df = read.csv(opt$input_ref_file, sep="\t", stringsAsFactors=FALSE)
+reference_labs_df = read.csv(opt$input_ref_file, sep="\t", stringsAsFactors=FALSE, comment.char = "#")
 reference_labs = reference_labs_df[, opt$label_column_ref]
 num_iter = opt$num_iterations
 ontology = opt$ontology_graph

--- a/get_tool_performance_table.R
+++ b/get_tool_performance_table.R
@@ -117,7 +117,9 @@ suppressPackageStartupMessages(require(yaml))
 
 # file names must start with the tool name 
 file_names = list.files(opt$input_dir, full.names=TRUE)
-predicted_labs_tables = lapply(file_names, function(file) read.csv(file, sep="\t", stringsAsFactors=FALSE))
+predicted_labs_tables = lapply(file_names, function(file) read.csv(file, sep="\t", stringsAsFactors=FALSE, comment.char = "#"))
+# extract corresponding tools 
+tools = sapply(file_names, function(file) extract_metadata(file)[['tool']])
 pred_labs_col = opt$label_column_pred
 barcode_ref = opt$barcode_col_ref
 barcode_pred = opt$barcode_col_pred
@@ -146,7 +148,8 @@ prop_unlab_reference = get_unlab_rate(reference_labs_df[, ref_labs_col], unlabel
 # iterate through tools' outputs and calculate relevant statistics per tool
 .get_metrics = function(idx){
     predicted_labs_df = predicted_labs_tables[[idx]]
-    tool = unlist(strsplit(basename(file_names[idx]), "_"))[1]
+    #tool = unlist(strsplit(basename(file_names[idx]), "_"))[1]
+    tool = tools[idx]
     print(paste("Evaluating tool:", tool, sep = " "))
 
     # check reference cell IDs match predicted cell IDs
@@ -189,5 +192,6 @@ if(opt$parallel){
 }
 
 output_table = data.frame(do.call(rbind, metrics_lst))
+print(output_table)
 output_table = output_table[order(output_table$Combined_score), ]
 write.table(output_table, file = opt$output_path, sep ="\t", row.names=FALSE)

--- a/get_tool_performance_table.R
+++ b/get_tool_performance_table.R
@@ -192,6 +192,5 @@ if(opt$parallel){
 }
 
 output_table = data.frame(do.call(rbind, metrics_lst))
-print(output_table)
 output_table = output_table[order(output_table$Combined_score), ]
 write.table(output_table, file = opt$output_path, sep ="\t", row.names=FALSE)

--- a/run_post_install_tests.bats
+++ b/run_post_install_tests.bats
@@ -8,7 +8,8 @@
     run rm -f $label_cl_dict && build_cell_ontology_dict.R\
                         --input-dir $SDRF_dir\
                         --condensed-sdrf\
-                        --output-dict-path $label_cl_dict
+                        --output-dict-path $label_cl_dict\
+                        --output-text-path $label_cl_txt
 
     echo "status = ${status}"
     echo "output = ${output}"

--- a/run_post_install_tests.sh
+++ b/run_post_install_tests.sh
@@ -54,6 +54,7 @@ export label_column_ref='Sample.Characteristic.cell.type.'
 export label_column_pred='predicted_label'
 
 export label_cl_dict=$output_dir/'label_cl_dict.rds'
+export label_cl_txt=$output_dir/'label_cl_txt.tsv'
 export tool_perf_table=$output_dir/'tool_perf_table.tsv'
 export empirical_dist=$output_dir/'empirical_dist_list.rds'
 export tool_table_pvals=$output_dir/'tool_pvals.tsv'


### PR DESCRIPTION
- found and solved a bug  - should not coerce CL term to lowercase, as this breaks semantic similarity computations 
- There was a problem with assumptions on specific file naming patterns: Galaxy would transform file names after uploading them and therefore provided information would be lost. A possible solution to this problem is adding metadata lines to the top of predicted label files, e.g. `# tool <tool>` and `# dataset <dataset>`. Logic was added to parse and write such lines where needed. 