### PR TITLE
add parameter to specify inferred cell type

### DIFF
--- a/build_cell_ontology_dict.R
+++ b/build_cell_ontology_dict.R
@@ -46,6 +46,13 @@ option_list = list(
         help = 'Name of the cell ontology terms column in SDRF files (must be identical across all files)'
     ),
     make_option(
+        c("-f", "--inferred-cell-type"),
+        action = "store_true",
+        default = TRUE,
+        type = 'logical',
+        help = 'Should inferred cell type be used?'
+    ),
+    make_option(
         c("-o", "--output-dict-path"),
         action = "store",
         default = NA,
@@ -62,7 +69,7 @@ option_list = list(
 )
 
 # parse arguments 
-opt = wsc_parse_args(option_list, mandatory = c("input_dir", "output_dict_path"))
+opt = wsc_parse_args(option_list, mandatory = c("input_dir", "output_dict_path", "output_text_path"))
 # source function definitions 
 script_dir = dirname(strsplit(commandArgs()[grep('--file=', commandArgs())], '=')[[1]][2])
 source(file.path(script_dir, 'cell_types_utils.R'))
@@ -84,8 +91,12 @@ if(condensed){
 # then map each label to corresponding CL term in a hash table 
 .map_cell_labels = function(df, hash_table, condensed){
     if(condensed){
+        ct = "cell type"
+        if(opt$inferred_cell_type){
+            ct = "inferred cell type"
+        }
         # select rows which have cell type 
-        df = df[df[, 5] == "cell type", ]
+        df = df[df[, 5] == ct, ]
         cell_labs = tolower(df[, 6])
         cl_terms = df[, 7]
     } else {

--- a/build_cell_ontology_dict.R
+++ b/build_cell_ontology_dict.R
@@ -34,7 +34,7 @@ option_list = list(
     make_option(
         c("-l", "--cell-label-col-name"),
         action = "store",
-        default = "cell.type",
+        default = "inferred cell type",
         type = 'character',
         help = 'Name of the cell label column in SDRF files (must be identical across all files)'
     ),
@@ -44,13 +44,6 @@ option_list = list(
         default = "cell.type.ontology",
         type = 'character',
         help = 'Name of the cell ontology terms column in SDRF files (must be identical across all files)'
-    ),
-    make_option(
-        c("-f", "--inferred-cell-type"),
-        action = "store_true",
-        default = TRUE,
-        type = 'logical',
-        help = 'Should inferred cell type be used?'
     ),
     make_option(
         c("-o", "--output-dict-path"),
@@ -73,6 +66,7 @@ opt = wsc_parse_args(option_list, mandatory = c("input_dir", "output_dict_path",
 # source function definitions 
 script_dir = dirname(strsplit(commandArgs()[grep('--file=', commandArgs())], '=')[[1]][2])
 source(file.path(script_dir, 'cell_types_utils.R'))
+cell_label = opt$cell_label_col_name
 
 # import the rest of dependencies 
 suppressPackageStartupMessages(require(hash))
@@ -91,16 +85,12 @@ if(condensed){
 # then map each label to corresponding CL term in a hash table 
 .map_cell_labels = function(df, hash_table, condensed){
     if(condensed){
-        ct = "cell type"
-        if(opt$inferred_cell_type){
-            ct = "inferred cell type"
-        }
         # select rows which have cell type 
-        df = df[df[, 5] == ct, ]
+        df = df[df[, 5] == cell_label, ]
         cell_labs = tolower(df[, 6])
         cl_terms = df[, 7]
     } else {
-        cell_labs = tolower(df[, opt$cell_label_col_name])
+        cell_labs = tolower(df[, cell_label])
         cl_terms = df[, opt$cell_ontology_col_name]
     }
     

--- a/label_analysis_run_post_install_tests.bats
+++ b/label_analysis_run_post_install_tests.bats
@@ -8,7 +8,6 @@
     run rm -f $label_cl_dict && build_cell_ontology_dict.R\
                         --input-dir $SDRF_dir\
                         --condensed-sdrf\
-                        --inferred-cell-type\
                         --output-dict-path $label_cl_dict\
                         --output-text-path $label_cl_txt
 

--- a/label_analysis_run_post_install_tests.bats
+++ b/label_analysis_run_post_install_tests.bats
@@ -8,6 +8,7 @@
     run rm -f $label_cl_dict && build_cell_ontology_dict.R\
                         --input-dir $SDRF_dir\
                         --condensed-sdrf\
+                        --inferred-cell-type\
                         --output-dict-path $label_cl_dict\
                         --output-text-path $label_cl_txt
 


### PR DESCRIPTION
This PR adds a parameter to control whether inferred cell type of just cell type field is used to generate a label - ontology term mapping in `build_cell_ontology_dict.R`. 