### PR TITLE
Feature/fix label aggregation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A common output format across tools is assumed - a tab-separated table with 3 co
 |ERR2632412 | memory B cell | 0.8|
 |ERR2632413 | memory B cell | 0.8|
 
+Example output tables can be found [here](https://github.com/ebi-gene-expression-group/cell-types-analysis/tree/master/example_output).
+
 **Metadata**
 
 In order to keep track of information about tool and training dataset which produced given table, add metadata fields to the top of the file in the following format:

--- a/cell_types_utils.R
+++ b/cell_types_utils.R
@@ -3,7 +3,7 @@
 # Define global variables 
 # list of unlabelled cell types
 # NB: keep these relevant to the tools' output
-unlabelled = c("unassigned", "unknown", 'rand','node','ambiguous', NA)
+unlabelled = c("unassigned", "unknown", 'rand','node','ambiguous', NA, "not available")
 
 # add common words here to improve specificity of word-matching method 
 trivial_terms = c("cell", "of", "tissue", "entity", "type") 

--- a/combine_tool_outputs.R
+++ b/combine_tool_outputs.R
@@ -103,7 +103,7 @@ if(opt$scores){
     scores = do.call(cbind, scores)
 
     .get_top_scores = function(score_list, top_n){
-        sort_lst = sort(score_list, index.return=TRUE, na.last=TRUE)
+        sort_lst = sort(score_list, index.return=TRUE, decreasing=TRUE)
         # restrict to top_n items
         top_items = lapply(sort_lst, function(v) v[1:top_n])
         return(top_items)
@@ -116,11 +116,10 @@ if(opt$scores){
     # top_items contains both sorted elements and corresponding indices
     # select columns of the label array and corresponding datasets by this index 
     sorted_lab_idx = lapply(seq_along(top_items), function(idx) as.numeric(unlist(top_items[[idx]][2])))
-    top_labels = lapply(seq_along(nrow(labels)), function(idx) labels[ idx, sorted_lab_idx[[idx]] ])
+    top_labels = lapply(1:nrow(labels), function(idx) labels[ idx, sorted_lab_idx[[idx]] ])
     top_labels = data.frame(do.call(rbind, top_labels))
     names = paste("label", c(1:top_n), sep="_")
     colnames(top_labels) = names
-
     # determine which datasets produced top predicitons for each cell
     top_datasets = lapply(sorted_lab_idx, function(idx_lst) datasets[idx_lst])
     top_datasets = data.frame(do.call(rbind, top_datasets))


### PR DESCRIPTION
Fix minor bugs in generation of prediction tables:
- reverse the order of sorting when selecting top labels by score 
- correct a wrong index in a `lapply()` iterator when generating output tables
- correct `rbind` to `cbind` when building a score-free table
