### PR TITLE
add downsampling script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
       conda config --add channels bioconda;
       conda config --add channels ebi-gene-expression-group;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-cairo r-yaml r-hash=2.2.6.1 r-foreach r-doparallel r-matrixstats bioconductor-onassis openjdk=8.0.152 r-reshape2=1.4.3 r-data.table=1.12.8 r-optparse r-workflowscriptscommon bats r-stringi;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-cairo r-yaml r-hash=2.2.6.1 r-foreach r-doparallel r-matrixstats bioconductor-onassis openjdk=8.0.152 r-reshape2=1.4.3 r-data.table=1.12.8 r-optparse r-workflowscriptscommon bats r-stringi dropletutils-scripts;
     fi
 
 install:

--- a/cell_types_utils.R
+++ b/cell_types_utils.R
@@ -3,7 +3,7 @@
 # Define global variables 
 # list of unlabelled cell types
 # NB: keep these relevant to the tools' output
-unlabelled = c("unassigned", "unknown", 'rand','node','ambiguous', NA, "not available")
+unlabelled = c("unassigned", "unknown", 'rand','node','ambiguous', NA, "not available", "")
 
 # add common words here to improve specificity of word-matching method 
 trivial_terms = c("cell", "of", "tissue", "entity", "type") 

--- a/downsample_cells.R
+++ b/downsample_cells.R
@@ -1,0 +1,131 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages(require(optparse))
+suppressPackageStartupMessages(require(workflowscriptscommon))
+
+# When training classifiers, avoid memory overflow by weighted down-sampling of cells.
+# The most prevalent cell types are filtered out first, so less-represented cells are not under risk of being removed. 
+
+option_list = list(
+    make_option(
+        c("-m", "--expression-data"),
+        action = "store",
+        default = NA,
+        type = 'character',
+        help = '10xGenomics-type directory holding expression matrix, genes, and barcodes'
+    ),
+    make_option(
+        c("-m", "--metadata"),
+        action = "store",
+        default = NA,
+        type = 'character',
+        help = 'Metadata file mapping cells to cell types'
+    ),
+    make_option(
+        c("-c", "--cell-id-field"),
+        action = "store",
+        default = "id",
+        type = 'character',
+        help = 'Name of cell id column in metada file'
+    ),
+    make_option(
+        c("-c", "--cell-type-field"),
+        action = "store",
+        default = "inferred.cell.type",
+        type = 'character',
+        help = 'Name of cell type column in metada file'
+    ),
+    make_option(
+        c("-l", "--array-size-limit"),
+        action = "store",
+        default = 2000000000,
+        type = 'numeric',
+        help = 'Maximum length of R array'
+    ),
+    make_option(
+        c("-s", "--sampling-rate"),
+        action = "store",
+        default = 0.1,
+        type = 'numeric',
+        help = 'Percantage of cells to be removed in a single iteration'
+    ),
+    make_option(
+        c("-o", "--output-dir"),
+        action = "store",
+        default = NA,
+        type = 'character',
+        help = 'Output directory for downsampled expression data'
+    ),
+    make_option(
+        c("-n", "--metadata-upd"),
+        action = "store",
+        default = NA,
+        type = 'character',
+        help = 'Updated metadata file output path'
+    )
+)
+
+opt = wsc_parse_args(option_list, mandatory = c('expression_data', 'metadata', 'output_dir', 'metadata_upd'))
+suppressPackageStartupMessages(require(Matrix))
+
+expr_data = opt$expression_data
+genes = read.csv(paste(expr_data, "genes.tsv", sep="/"), sep="\t", stringsAsFactors = FALSE, header = FALSE)
+barcodes = read.csv(paste(expr_data, "barcodes.tsv", sep="/"), sep="\t", stringsAsFactors = FALSE, header = FALSE)
+cell_num_limit = floor(opt$array_size_limit / nrow(genes))
+current_cell_num = nrow(barcodes)
+
+# if no down-samling is required, simply return the output
+if(current_cell_num <= cell_num_limit){
+    system(paste("mv", opt$expression_data, opt$output_dir, sep=" "))
+    system(paste("mv", opt$metadata, opt$metadata_upd, sep=" "))
+    quit(status = 0)
+}
+
+# parse the remaining data
+cell_labels = opt$cell_type_field
+cell_id_col = opt$cell_id_col
+matrix = Matrix::readMM(paste(expr_data, "matrix.mtx", sep="/"))
+metadata = read.csv(opt$metadata, sep = "\t", stringsAsFactors = FALSE)
+# remove technical duplicate rows
+metadata = metadata[which(!duplicated(metadata[, cell_id_col])), ]
+
+# get indices of all cell types
+num_per_cell_type = table(metadata$cell_labels)
+grouped_indices = lapply(seq_along(num_per_cell_type),
+                   function(idx) which(num_per_cell_type$cell_labels == names(num_per_cell_type[idx])))
+
+# build a vector of cell indices to be removed 
+total_cells_to_remove = c()
+current_cell_type_idx = 1
+
+while(current_cell_num >= cell_num_limit){
+    sample_size = floor(length(grouped_indices[[current_cell_type_idx]]) * opt$sampling_rate)
+    # sample by index, then select cells by that index
+    i = sample(1:length(grouped_indices[[current_cell_type_idx]]), sample_size)
+    current_cells_to_remove = grouped_indices[[current_cell_type_idx]][i]
+    total_cells_to_remove = append(total_cells_to_remove, current_cells_to_remove)
+    # remove sampled cells 
+    grouped_indices[[current_cell_type_idx]] = grouped_indices[[current_cell_type_idx]][-i]
+
+    # continue sampling from the same cell type or switch to next one    
+    if(current_cell_type_idx < length(num_per_cell_type)){
+        if(length(grouped_indices[[current_cell_type_idx]] < length(grouped_indices[[current_cell_type_idx + 1]]))){
+            current_cell_type_idx = current_cell_type_idx + 1
+        }
+    } else{
+        current_cell_type_idx = 1
+    }
+    current_cell_num = current_cell_num - sample_size
+}
+
+# subset matrix, barcodes and metadata by the generated index
+matrix = matrix[, -total_cells_to_remove]
+barcodes = barcodes[-total_cells_to_remove, ]
+metadata = metadata[-total_cells_to_remove, ]
+
+# write data
+Matrix::writeMM(matrix, paste(opt$output_dir, "matrix.mtx", sep="/"))
+write.table(genes, paste(opt$output_dir, "genes.tsv", sep="/"), sep="\t")
+write.table(barcodes, paste(opt$output_dir, "barcodes.tsv", sep="/"), sep="\t", row.names=FALSE)
+write.table(metadata, opt$metadata_upd, sep="\t")
+

--- a/downsample_cells.R
+++ b/downsample_cells.R
@@ -78,6 +78,8 @@ current_cell_num = nrow(barcodes)
 if(current_cell_num <= cell_num_limit){
     system(paste("mv", opt$expression_data, opt$output_dir, sep=" "))
     system(paste("mv", opt$metadata, opt$metadata_upd, sep=" "))
+    cat(paste("Matrix not large enough, down-sampling is not required.\nData are moved to ",
+               opt$output_dir, " and ", opt$metadata_upd, "\n", sep=""))
     quit(status = 0)
 }
 

--- a/exclusions.yml
+++ b/exclusions.yml
@@ -5,6 +5,8 @@ unlabelled:
   - node
   - ambiguous
   - NA
+  - ''
+  - 'not available'
 trivial_terms:
   - cell
   - of

--- a/label_analysis_run_post_install_tests.bats
+++ b/label_analysis_run_post_install_tests.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 @test "Build label - CL term mapping" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$label_cl_dict" ]; then
         skip "$label_cl_dict exists and use_existing_outputs is set to 'true'"
     fi
@@ -20,6 +21,7 @@
 }
 
 @test "build tool evaluation table" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$tool_perf_table" ]; then
         skip "$tool_perf_table exists and use_existing_outputs is set to 'true'"
     fi
@@ -47,6 +49,7 @@
 }
 
 @test "generate empirical CDF" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$empirical_dist" ]; then
         skip "$empirical_dist exists and use_existing_outputs is set to 'true'"
     fi
@@ -70,6 +73,7 @@
 }
 
 @test "obtain p-values for calculated statistics" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$tool_table_pvals" ]; then
         skip "$tool_table_pvals exists and use_existing_outputs is set to 'true'"
     fi
@@ -87,6 +91,7 @@
 }
 
 @test "combine results" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$combined_results" ]; then
         skip "$combined_results exists and use_existing_outputs is set to 'true'"
     fi
@@ -106,6 +111,7 @@
 }
 
 @test "Get consensus output" {
+    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$summary_table_path" ]; then
         skip "$summary_table_path exists and use_existing_outputs is set to 'true'"
     fi
@@ -127,4 +133,25 @@
 
     [ "$status" -eq 0 ]
     [ -f "$summary_table_path" ]
+}
+
+@test "Run matrix down-sampling" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -d "$sampling_out_dir" ]; then
+        skip "$sampling_out_dir exists and use_existing_outputs is set to 'true'"
+    fi
+
+    run rm -rf $sampling_out_dir && downsample_cells.R\
+                    --expression-data $sampling_test_10x_data\
+                    --metadata $sampling_test_sdrf\
+                    --cell-id-field $sampling_cell_id_field\
+                    --cell-type-field $sampling_cell_type_field\
+                    --array-size-limit $sampling_arr_size_limit\
+                    --output-dir $sampling_out_dir\
+                    --metadata-upd $sampling_metadata_upd
+
+    echo "status = ${status}"
+    echo "output = ${output}"
+
+    [ "$status" -eq 0 ]
+    [ -d "$sampling_out_dir" ]
 }

--- a/label_analysis_run_post_install_tests.bats
+++ b/label_analysis_run_post_install_tests.bats
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 
 @test "Build label - CL term mapping" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$label_cl_dict" ]; then
         skip "$label_cl_dict exists and use_existing_outputs is set to 'true'"
     fi
@@ -21,7 +20,6 @@
 }
 
 @test "build tool evaluation table" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$tool_perf_table" ]; then
         skip "$tool_perf_table exists and use_existing_outputs is set to 'true'"
     fi
@@ -49,7 +47,6 @@
 }
 
 @test "generate empirical CDF" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$empirical_dist" ]; then
         skip "$empirical_dist exists and use_existing_outputs is set to 'true'"
     fi
@@ -73,7 +70,6 @@
 }
 
 @test "obtain p-values for calculated statistics" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$tool_table_pvals" ]; then
         skip "$tool_table_pvals exists and use_existing_outputs is set to 'true'"
     fi
@@ -91,7 +87,6 @@
 }
 
 @test "combine results" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$combined_results" ]; then
         skip "$combined_results exists and use_existing_outputs is set to 'true'"
     fi
@@ -111,7 +106,6 @@
 }
 
 @test "Get consensus output" {
-    skip
     if [ "$use_existing_outputs" = 'true' ] && [ -f "$summary_table_path" ]; then
         skip "$summary_table_path exists and use_existing_outputs is set to 'true'"
     fi

--- a/label_analysis_run_post_install_tests.sh
+++ b/label_analysis_run_post_install_tests.sh
@@ -45,6 +45,15 @@ mkdir -p $output_dir
 export eval_input_dir=$data_dir/'results_dir/'
 export res_to_combine=$data_dir/'prod_outputs_scpred/'
 export ref_labels_file=$data_dir/'reference_sdrf.tsv'
+
+export sampling_test_10x_data=$data_dir/'10x_data/'
+export sampling_test_sdrf=$data_dir/'E-GEOD-83139.sdrf.txt'
+export sampling_cell_id_field='FactorValue..single.cell.identifier.'
+export sampling_cell_type_field='Characteristics..inferred.cell.type.'
+export sampling_arr_size_limit=2454500
+export sampling_out_dir='10x_data_sampled'
+export sampling_metadata_upd='E-GEOD-83139.sdrf_sampled.txt'
+
 export SDRF_dir=$data_dir/'SDRFs'
 export SDRF_cell_types="cell type"
 export tmpdir="TMPDIR"

--- a/label_analysis_run_post_install_tests.sh
+++ b/label_analysis_run_post_install_tests.sh
@@ -82,7 +82,7 @@ export top_labels_num=2
 export use_existing_outputs
 
 # retrieve test data 
-test_data_url="ftp://ftp.ebi.ac.uk/pub/databases/arrayexpress/data/atlas/cell-types-project-test-data/cell_types_analysis_test_data.tar.gz"
+test_data_url="http://ftp.ebi.ac.uk/pub/databases/arrayexpress/data/atlas/cell-types-project-test-data/cell_types_analysis_test_data.tar.gz"
 test_data_archive=$test_working_dir/`basename $test_data_url`
 
 if [ ! -e "$test_data_archive" ]; then

--- a/label_analysis_run_post_install_tests.sh
+++ b/label_analysis_run_post_install_tests.sh
@@ -82,8 +82,13 @@ export top_labels_num=2
 export use_existing_outputs
 
 # retrieve test data 
-wget "ftp://ftp.ebi.ac.uk/pub/databases/arrayexpress/data/atlas/cell-types-project-test-data/cell_types_analysis_test_data.tar.gz" -P $test_working_dir
-tar -xzvf $test_working_dir/'cell_types_analysis_test_data.tar.gz' -C $test_working_dir
+test_data_url="ftp://ftp.ebi.ac.uk/pub/databases/arrayexpress/data/atlas/cell-types-project-test-data/cell_types_analysis_test_data.tar.gz"
+test_data_archive=$test_working_dir/`basename $test_data_url`
+
+if [ ! -e "$test_data_archive" ]; then
+    wget $test_data_url -P $test_working_dir
+    tar -xzvf $test_data_archive -C $test_working_dir
+fi
 
 # Derive the tests file name from the script name
 tests_file="${script_name%.*}".bats

--- a/label_analysis_run_post_install_tests.sh
+++ b/label_analysis_run_post_install_tests.sh
@@ -83,9 +83,11 @@ export use_existing_outputs
 
 # retrieve test data 
 test_data_url="http://ftp.ebi.ac.uk/pub/databases/arrayexpress/data/atlas/cell-types-project-test-data/cell_types_analysis_test_data.tar.gz"
-test_data_archive=$test_working_dir/`basename $test_data_url`
+test_data_archive=$test_working_dir/$(basename $test_data_url)
 
 if [ ! -e "$test_data_archive" ]; then
+    echo "Importing test data..."
+    echo $test_data_archive
     wget $test_data_url -P $test_working_dir
     tar -xzvf $test_data_archive -C $test_working_dir
 fi


### PR DESCRIPTION
This PR adds a script that does cell-type stratified downsampling to avoid memory issues with large datasets. 

The proportions of the top-represented cell types are progressively reduced to those of lower-ranked types until projected cell numbers fall below maximum, identifying cell types to down-sample. These are types are then reduced by a number of cells proportional to their over-representation to remove the required number of cells. 