### PR TITLE
fix issue with R breaking field names

### DIFF
--- a/downsample_cells.R
+++ b/downsample_cells.R
@@ -251,5 +251,5 @@ write10xCounts(opt$output_dir, assays(sce)[[1]], barcodes = sce$Barcode,
 colnames(colData(sce))[1] <- opt$cell_id_field
 colData(sce) <- colData(sce)[, -2] 
 # write outputs and avoid column names mangling
-write.table(data.frame(colData(sce), check.names = FALSE), opt$metadata_upd, sep="\t")
+write.table(data.frame(colData(sce), check.names = FALSE), opt$metadata_upd, row.names = FALSE, sep="\t")
 print("Outputs written successfully")

--- a/downsample_cells.R
+++ b/downsample_cells.R
@@ -251,6 +251,5 @@ write10xCounts(opt$output_dir, assays(sce)[[1]], barcodes = sce$Barcode,
 colnames(colData(sce))[1] <- opt$cell_id_field
 colData(sce) <- colData(sce)[, -2] 
 # write outputs and avoid column names mangling
-write(paste(colnames(colData(sce)), collapse="\t"), opt$metadata_upd, sep="\t")
-write.table(colData(sce), opt$metadata_upd, col.names=F, row.names=FALSE, sep="\t", append=T)
+write.table(data.frame(colData(sce), check.names = FALSE), opt$metadata_upd, sep="\t")
 print("Outputs written successfully")

--- a/downsample_cells.R
+++ b/downsample_cells.R
@@ -228,7 +228,7 @@ if(downsampling_required){
 }
 if(minor_cell_types_present){
     cell_type_freqs <- sort(table(colData(sce)[[opt$cell_type_field]]), decreasing = FALSE)
-    cell_types_to_drop = cell_type_freqs[cell_type_freqs < cell_count_threshold]
+    cell_types_to_drop = names(cell_type_freqs[cell_type_freqs < cell_count_threshold])
     # need to make sure those rare cells are still present after down-sampling
     if(length(cell_types_to_drop) > 0){
         print("Removing cell types with low frequency...")
@@ -250,5 +250,7 @@ write10xCounts(opt$output_dir, assays(sce)[[1]], barcodes = sce$Barcode,
 # rename cell id field and remove redundant column
 colnames(colData(sce))[1] <- opt$cell_id_field
 colData(sce) <- colData(sce)[, -2] 
-write.table(colData(sce), opt$metadata_upd, sep="\t")
+# write outputs and avoid column names mangling
+write(paste(colnames(colData(sce)), collapse="\t"), opt$metadata_upd, sep="\t")
+write.table(colData(sce), opt$metadata_upd, col.names=F, row.names=FALSE, sep="\t", append=T)
 print("Outputs written successfully")


### PR DESCRIPTION
When data frame to a file, R automatically introduces dots instead of spaces in the field names. (Obviously, under normal circumstances nobody uses spaces there anyway, but we have no choice here).  To avoid this, we have to write field names to a file in a separate step. In addition, a minor bug is fixed. 